### PR TITLE
added-debug-color

### DIFF
--- a/src/panner-node/index.html
+++ b/src/panner-node/index.html
@@ -42,7 +42,7 @@
               position="{{position}}"
               volume="10"
             >
-              <a-box look-at="#player" data-clickable>
+              <a-box id="{{id}}-box" look-at="#player" data-clickable>
                 <a-text
                   value="{{id}}"
                   align="center"

--- a/src/panner-node/main.js
+++ b/src/panner-node/main.js
@@ -3,6 +3,7 @@ import {
   LEVELS,
   PLAY_INTERVAL,
   SPEAKER_RADIUS,
+  DEBUG,
 } from "@utils/constants.js";
 import { distributeSpeakers } from "@utils/distribute-speakers.js";
 import "@utils/back-button.js";
@@ -21,7 +22,7 @@ AFRAME.registerState({
     })),
     currentPlayingSpeaker: "",
     score: 0,
-    messageBox: "What speaker is playing?",
+    messageBox: "Press Start to play",
     currentLevel: 0,
     isPlaying: null,
     sphereRadius: SPEAKER_RADIUS,
@@ -30,12 +31,18 @@ AFRAME.registerState({
 
   handlers: {
     playLoop: function (state, action) {
-      console.log(state);
       if (state.currentPlayingSpeaker !== `${action.speaker}`) return;
       const playingSpeaker = document.querySelector(
         `#speaker-${action.speaker}`
       );
       playingSpeaker.components["sound"].playSound();
+
+      if (DEBUG) {
+        const speakerBox = document.querySelector(
+          `#speaker-${action.speaker}-box`
+        );
+        speakerBox.setAttribute("material", { color: "red" });
+      }
 
       setTimeout(() => {
         if (state.currentPlayingSpeaker === `${action.speaker}`)
@@ -49,6 +56,10 @@ AFRAME.registerState({
       const rand = Math.floor(Math.random() * (63 + 1));
       // update currentPlayingSpeaker
       state.currentPlayingSpeaker = `${rand}`;
+      // update message box
+      AFRAME.scenes[0].emit("updateMessageBox", {
+        message: "What Speaker is playing?",
+      });
       // play audio from random speaker
       state.isPlaying = true;
       AFRAME.scenes[0].emit("playLoop", { speaker: rand });
@@ -77,7 +88,6 @@ AFRAME.registerState({
         `#speaker-${state.currentPlayingSpeaker}`
       );
       state.isPlaying = false;
-      state.currentPlayingSpeaker = "";
       playingSpeaker.components["sound"].stopSound();
 
       // check if clicked speaker is equal to current playing speaker
@@ -98,16 +108,22 @@ AFRAME.registerState({
         });
       }
 
+      // empty currentPlayingSpeaker
+      state.currentPlayingSpeaker = "";
       // increment level
       state.currentLevel += 1;
       //  wait for n seconds
       setTimeout(() => {
+        if (DEBUG) {
+          const speakerBox = document.querySelector(
+            `#speaker-${action.speakerClicked}-box`
+          );
+          speakerBox.setAttribute("material", { color: "white" });
+        }
+
         // check if levels < 10
         if (state.currentLevel < LEVELS) {
           // if yes, emit new playFromRandomSpeaker
-          AFRAME.scenes[0].emit("updateMessageBox", {
-            message: "What Speaker is playing?",
-          });
           AFRAME.scenes[0].emit("playFromRandomSpeaker");
         } else {
           // else set messagebox to "Game Over"
@@ -118,13 +134,6 @@ AFRAME.registerState({
         }
       }, TIME_BETWEEN_LEVELS);
     },
-  },
-});
-
-AFRAME.registerComponent("wait-for-room", {
-  dependencies: ["resonance-audio-room"],
-  init: function () {
-    AFRAME.scenes[0].emit("playFromRandomSpeaker");
   },
 });
 

--- a/src/resonance-audio/index.html
+++ b/src/resonance-audio/index.html
@@ -57,7 +57,7 @@
                 position="{{position}}"
                 resonance-audio-src="src: {{audioSrc}}; autoplay: false; loop: false; gain: 10"
               >
-                <a-box look-at="#player" data-clickable>
+                <a-box id="{{id}}-box" look-at="#player" data-clickable>
                   <a-text
                     value="{{id}}"
                     align="center"

--- a/src/resonance-audio/main.js
+++ b/src/resonance-audio/main.js
@@ -3,6 +3,7 @@ import {
   LEVELS,
   PLAY_INTERVAL,
   SPEAKER_RADIUS,
+  DEBUG,
 } from "@utils/constants.js";
 import { distributeSpeakers } from "@utils/distribute-speakers.js";
 import "@utils/back-button.js";
@@ -21,7 +22,7 @@ AFRAME.registerState({
     })),
     currentPlayingSpeaker: "",
     score: 0,
-    messageBox: "What speaker is playing?",
+    messageBox: "Press Start to play",
     currentLevel: 0,
     isPlaying: null,
     sphereRadius: SPEAKER_RADIUS,
@@ -30,10 +31,16 @@ AFRAME.registerState({
 
   handlers: {
     playLoop: function (state, action) {
-      console.log(state);
       if (state.currentPlayingSpeaker !== `${action.speaker}`) return;
       const playingSpeaker = document.querySelector(`#src-${action.speaker}`);
       playingSpeaker.play();
+
+      if (DEBUG) {
+        const speakerBox = document.querySelector(
+          `#speaker-${action.speaker}-box`
+        );
+        speakerBox.setAttribute("material", { color: "red" });
+      }
 
       setTimeout(() => {
         if (state.currentPlayingSpeaker === `${action.speaker}`)
@@ -47,6 +54,10 @@ AFRAME.registerState({
       const rand = Math.floor(Math.random() * (63 + 1));
       // update currentPlayingSpeaker
       state.currentPlayingSpeaker = `${rand}`;
+      // update message box
+      AFRAME.scenes[0].emit("updateMessageBox", {
+        message: "What Speaker is playing?",
+      });
       // play audio from random speaker
       state.isPlaying = true;
       AFRAME.scenes[0].emit("playLoop", { speaker: rand });
@@ -75,7 +86,6 @@ AFRAME.registerState({
         `#src-${state.currentPlayingSpeaker}`
       );
       state.isPlaying = false;
-      state.currentPlayingSpeaker = "";
       playingSpeaker.pause();
 
       // check if clicked speaker is equal to current playing speaker
@@ -96,16 +106,21 @@ AFRAME.registerState({
         });
       }
 
+      // empty currentPlayingSpeaker
+      state.currentPlayingSpeaker = "";
       // increment level
       state.currentLevel += 1;
       //  wait for n seconds
       setTimeout(() => {
+        if (DEBUG) {
+          const speakerBox = document.querySelector(
+            `#speaker-${action.speakerClicked}-box`
+          );
+          speakerBox.setAttribute("material", { color: "white" });
+        }
         // check if levels < 10
         if (state.currentLevel < LEVELS) {
           // if yes, emit new playFromRandomSpeaker
-          AFRAME.scenes[0].emit("updateMessageBox", {
-            message: "What Speaker is playing?",
-          });
           AFRAME.scenes[0].emit("playFromRandomSpeaker");
         } else {
           // else set messagebox to "Game Over"
@@ -121,9 +136,6 @@ AFRAME.registerState({
 
 AFRAME.registerComponent("wait-for-room", {
   dependencies: ["resonance-audio-room"],
-  init: function () {
-    AFRAME.scenes[0].emit("playFromRandomSpeaker");
-  },
 });
 
 AFRAME.registerComponent("start-button", {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,5 @@
 export const TIME_BETWEEN_LEVELS = 3000;
-export const PLAY_INTERVAL = 5000;
+export const PLAY_INTERVAL = 5000; // TODO remove
 export const LEVELS = 3;
 export const SPEAKER_RADIUS = 10;
+export const DEBUG = true;


### PR DESCRIPTION
![image](https://github.com/CIMIL/SpatialAudioWebXR/assets/59342479/a7e06bd2-732d-40c4-b40f-1472ce2c4704)

Viene evidenziato il cubo in rosso. Rimane anche dopo aver cliccato fino alla riproduzione del prossimo suono.